### PR TITLE
Make assert_with_ulp() robust to empty tensors, NaN and Inf values

### DIFF
--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -608,7 +608,7 @@ def ulp(x: Union[ttnn.Tensor, torch.Tensor]) -> Union[ttnn.Tensor, torch.Tensor]
     return ulp_value
 
 
-def comp_ulp(golden, calculated, ulp_threshold):
+def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
     """
     Compute absolute error between two tensors in Units of Least Precision (ULP)
     """
@@ -617,9 +617,11 @@ def comp_ulp(golden, calculated, ulp_threshold):
     if torch.numel(golden) == 0 and torch.numel(calculated) == 0:
         return True, "Both tensors are empty"
 
+    if not allow_nonfinite and not torch.all(torch.isfinite(calculated)):
+        return False, "Calculated tensor contains non-finite values"
+
     if not _comp_finite(golden, calculated):
         return False, "Tensors are not finite at the same positions"
-
     # nonfinite elments can intefere with ULP error calculation
     # To avoid this, replace nan, +inf, -inf with 0
     # (we have already checked that both tensors have the same nonfinite elements)

--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -492,10 +492,10 @@ def is_close(a, b, rtol=1e-2, atol=1e-2, max_mag=2.0, max_mag_fraction=0.02):
     return torch.all(or_abs_rel)
 
 
-def _comp_finite(golden, calculated):
+def _comp_nonfinite(golden, calculated):
     """
-    Check whether two tensors are nonfinite (nan, inf, -inf) at the same positions.
-    If they are, then check whether nonfinite elements are the same.
+    Returns True if tensors contain the same non-finite values (nan, inf, -inf) at the same positions. Also returns True if all elements are finite.
+    Returns False if non-finite values differ between both tensors.
     """
 
     # torch.equal(['nan'], ['nan']] => False
@@ -620,7 +620,7 @@ def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
     if not allow_nonfinite and not torch.all(torch.isfinite(calculated)):
         return False, "Calculated tensor contains non-finite values"
 
-    if not _comp_finite(golden, calculated):
+    if not _comp_nonfinite(golden, calculated):
         return False, "Tensors are not finite at the same positions"
     # nonfinite elments can intefere with ULP error calculation
     # To avoid this, replace nan, +inf, -inf with 0

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -142,7 +142,7 @@ def assert_with_ulp(
         expected_result (Union[ttnn.Tensor, torch.Tensor]): The expected reference tensor
         actual_result (Union[ttnn.Tensor, torch.Tensor]): The actual tensor to compare against the reference
         ulp_threshold (float, optional): Maximum tolerated ULP distance. Defaults to 10.
-        allow_nonfinite (bool, optional): If disabled, any non-finite value (NaN, +inf, -inf) will trigger assertion. If enabled, it will also compare NaNs, +inf and inf.
+        allow_nonfinite (bool, optional): If disabled, any non-finite value (NaN, +inf, -inf) will trigger an assertion. If enabled, differences between non-finite values at the same positions will trigger an assertion.
 
     Note:
         The length of a single ULP is measured using the difference between two consecutive floating point numbers.

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -122,7 +122,10 @@ def assert_allclose(
 
 
 def assert_with_ulp(
-    expected_result: Union[ttnn.Tensor, torch.Tensor], actual_result: Union[ttnn.Tensor, torch.Tensor], ulp_threshold=10
+    expected_result: Union[ttnn.Tensor, torch.Tensor],
+    actual_result: Union[ttnn.Tensor, torch.Tensor],
+    ulp_threshold=10,
+    allow_nonfinite=False,
 ):
     """
     Assert that two tensors are similar within a given distance expressed in Units of Least Precision (ULP)
@@ -139,6 +142,7 @@ def assert_with_ulp(
         expected_result (Union[ttnn.Tensor, torch.Tensor]): The expected reference tensor
         actual_result (Union[ttnn.Tensor, torch.Tensor]): The actual tensor to compare against the reference
         ulp_threshold (float, optional): Maximum tolerated ULP distance. Defaults to 10.
+        allow_nonfinite (bool, optional): If disabled, any non-finite value (NaN, +inf, -inf) will trigger assertion. If enabled, it will also compare NaNs, +inf and inf.
 
     Note:
         The length of a single ULP is measured using the difference between two consecutive floating point numbers.
@@ -160,7 +164,7 @@ def assert_with_ulp(
         actual_result.shape
     ), f"list(expected_result.shape)={list(expected_result.shape)} vs list(actual_result.shape)={list(actual_result.shape)}"
 
-    ulp_passed, ulp_message = comp_ulp(expected_result, actual_result, ulp_threshold)
+    ulp_passed, ulp_message = comp_ulp(expected_result, actual_result, ulp_threshold, allow_nonfinite)
     assert ulp_passed, ulp_message
     return ulp_passed, ulp_message
 


### PR DESCRIPTION
Migrated from upstream PR 23533