### PR TITLE
#24504: Avoid modifying core grid in NdShardSpec for representing block sharding

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -26,7 +26,7 @@ struct NdToLegacyShardingParams {
     Shape shard_shape_nd;
     Layout layout = Layout::TILE;
     CoreCoord grid_size;
-    bool use_2d_grid_distribution = false;
+    ShardDistributionStrategy shard_distribution_strategy = ShardDistributionStrategy::ROUND_ROBIN_1D;
 
     TensorMemoryLayout memory_layout = TensorMemoryLayout::BLOCK_SHARDED;
     std::optional<Shape2D> shard_shape_2d;
@@ -179,7 +179,7 @@ TEST_P(NdToLegacyShardingTests, NdToLegacySharding) {
 
     CoreRangeSet cores(CoreRange(CoreCoord{0, 0}, CoreCoord{params.grid_size.x - 1, params.grid_size.y - 1}));
     NdShardSpec nd_shard_spec{
-        params.shard_shape_nd, cores, ShardOrientation::ROW_MAJOR, params.use_2d_grid_distribution};
+        params.shard_shape_nd, cores, ShardOrientation::ROW_MAJOR, params.shard_distribution_strategy};
     MemoryConfig memory_config{BufferType::L1, nd_shard_spec};
     TensorLayout tensor_layout(DataType::UINT16, PageConfig(params.layout), memory_config);
     TensorSpec tensor_spec(params.shape, tensor_layout);
@@ -676,7 +676,7 @@ INSTANTIATE_TEST_SUITE_P(
             .shard_shape_nd = Shape({1, 32, 32}),
             .layout = Layout::TILE,
             .grid_size = CoreCoord{3, 4},
-            .use_2d_grid_distribution = true,
+            .shard_distribution_strategy = ShardDistributionStrategy::GRID_2D,
             .memory_layout = TensorMemoryLayout::BLOCK_SHARDED,
             .shard_shape_2d = Shape2D{32, 32},
         },

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -20,13 +20,13 @@ struct LegacyToNdShardingParams {
     Layout layout = Layout::TILE;
 
     std::optional<Shape> shard_shape_nd;
-    std::optional<CoreCoord> grid_size;
 };
 struct NdToLegacyShardingParams {
     Shape shape;
     Shape shard_shape_nd;
     Layout layout = Layout::TILE;
     CoreCoord grid_size;
+    bool use_2d_grid_distribution = false;
 
     TensorMemoryLayout memory_layout = TensorMemoryLayout::BLOCK_SHARDED;
     std::optional<Shape2D> shard_shape_2d;
@@ -168,12 +168,7 @@ TEST_P(LegacyToNdShardingTests, LegacyToNdSharding) {
     ASSERT_EQ(nd_shard_spec.has_value(), params.shard_shape_nd.has_value());
     if (nd_shard_spec.has_value()) {
         ASSERT_EQ(nd_shard_spec->shard_shape, params.shard_shape_nd.value());
-        if (params.grid_size.has_value()) {
-            ASSERT_EQ(nd_shard_spec->grid.ranges().size(), 1);
-            ASSERT_EQ(nd_shard_spec->grid.ranges()[0].grid_size(), params.grid_size.value());
-        } else {
-            ASSERT_EQ(nd_shard_spec->grid, cores);
-        }
+        ASSERT_EQ(nd_shard_spec->grid, cores);
     }
 }
 
@@ -183,7 +178,8 @@ TEST_P(NdToLegacyShardingTests, NdToLegacySharding) {
     const auto& params = GetParam();
 
     CoreRangeSet cores(CoreRange(CoreCoord{0, 0}, CoreCoord{params.grid_size.x - 1, params.grid_size.y - 1}));
-    NdShardSpec nd_shard_spec{params.shard_shape_nd, cores, ShardOrientation::ROW_MAJOR};
+    NdShardSpec nd_shard_spec{
+        params.shard_shape_nd, cores, ShardOrientation::ROW_MAJOR, params.use_2d_grid_distribution};
     MemoryConfig memory_config{BufferType::L1, nd_shard_spec};
     TensorLayout tensor_layout(DataType::UINT16, PageConfig(params.layout), memory_config);
     TensorSpec tensor_spec(params.shape, tensor_layout);
@@ -533,7 +529,6 @@ INSTANTIATE_TEST_SUITE_P(
             .shard_shape_2d = Shape2D{32, 32},
             .layout = Layout::TILE,
             .shard_shape_nd = Shape({32, 32}),
-            .grid_size = CoreCoord{2, 4},
         },
         LegacyToNdShardingParams{
             .shape = Shape({2, 32 * 2, 32 * 2}),
@@ -541,7 +536,6 @@ INSTANTIATE_TEST_SUITE_P(
             .shard_shape_2d = Shape2D{32 * 2, 32},
             .layout = Layout::TILE,
             .shard_shape_nd = Shape({32 * 2, 32}),
-            .grid_size = CoreCoord{2, 2},
         },
         LegacyToNdShardingParams{
             .shape = Shape({2, 32 * 2, 32 * 2}),
@@ -549,7 +543,6 @@ INSTANTIATE_TEST_SUITE_P(
             .shard_shape_2d = Shape2D{32 * 3, 32},
             .layout = Layout::TILE,
             .shard_shape_nd = Shape({32 * 3, 32}),
-            .grid_size = CoreCoord{2, 2},
         },
         LegacyToNdShardingParams{
             .shape = Shape({2, 4, 4}),
@@ -557,7 +550,6 @@ INSTANTIATE_TEST_SUITE_P(
             .shard_shape_2d = Shape2D{2, 2},
             .layout = Layout::ROW_MAJOR,
             .shard_shape_nd = Shape({2, 2}),
-            .grid_size = CoreCoord{2, 4},
         },
         LegacyToNdShardingParams{
             .shape = Shape({2, 4}),
@@ -565,7 +557,6 @@ INSTANTIATE_TEST_SUITE_P(
             .shard_shape_2d = Shape2D{2, 2},
             .layout = Layout::ROW_MAJOR,
             .shard_shape_nd = Shape({2, 2}),
-            .grid_size = CoreCoord{2, 1},
         },
         LegacyToNdShardingParams{
             .shape = Shape({4}),
@@ -573,7 +564,6 @@ INSTANTIATE_TEST_SUITE_P(
             .shard_shape_2d = Shape2D{1, 2},
             .layout = Layout::ROW_MAJOR,
             .shard_shape_nd = Shape({2}),
-            .grid_size = CoreCoord{2, 1},
         },
         LegacyToNdShardingParams{
             .shape = Shape({}),
@@ -581,7 +571,6 @@ INSTANTIATE_TEST_SUITE_P(
             .shard_shape_2d = Shape2D{1, 1},
             .layout = Layout::ROW_MAJOR,
             .shard_shape_nd = Shape({1}),
-            .grid_size = CoreCoord{1, 1},
         },
         LegacyToNdShardingParams{
             .shape = Shape({2, 32 * 2, 32 * 2}),
@@ -681,6 +670,15 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{3, 4},
             .memory_layout = TensorMemoryLayout::BLOCK_SHARDED,
             .shard_shape_2d = std::nullopt,  // Can't convert, different shard distribution
+        },
+        NdToLegacyShardingParams{
+            .shape = Shape({2, 32 * 2, 32 * 2}),
+            .shard_shape_nd = Shape({1, 32, 32}),
+            .layout = Layout::TILE,
+            .grid_size = CoreCoord{3, 4},
+            .use_2d_grid_distribution = true,
+            .memory_layout = TensorMemoryLayout::BLOCK_SHARDED,
+            .shard_shape_2d = Shape2D{32, 32},
         },
         NdToLegacyShardingParams{
             .shape = Shape({2, 2, 4}),

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -24,13 +24,15 @@ public:
         tt::tt_metal::Shape shard_shape,
         tt::tt_metal::Shape2D page_shape,
         CoreRangeSet core_range_set,
-        ShardOrientation shard_orientation);
+        ShardOrientation shard_orientation,
+        bool use_2d_grid_distribution = false);
 
     BufferDistributionSpec(
         tt::tt_metal::Shape tensor_shape_in_pages,
         tt::tt_metal::Shape shard_shape_in_pages,
         CoreRangeSet core_range_set,
-        ShardOrientation shard_orientation);
+        ShardOrientation shard_orientation,
+        bool use_2d_grid_distribution = false);
 
     tt::tt_metal::Shape get_tensor_shape_in_pages() const { return tensor_shape_in_pages_; }
     tt::tt_metal::Shape get_shard_shape_in_pages() const { return shard_shape_in_pages_; }
@@ -57,6 +59,8 @@ public:
     }
 
 private:
+    std::vector<CoreCoord> compute_core_list(const CoreRangeSet& core_range_set, bool use_2d_grid_distribution);
+
     tt::tt_metal::Shape tensor_shape_in_pages_;
     tt::tt_metal::Shape shard_shape_in_pages_;
     ShardOrientation shard_orientation_ = ShardOrientation::ROW_MAJOR;

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -25,14 +25,14 @@ public:
         tt::tt_metal::Shape2D page_shape,
         CoreRangeSet core_range_set,
         ShardOrientation shard_orientation,
-        bool use_2d_grid_distribution = false);
+        ShardDistributionStrategy shard_distribution_strategy = ShardDistributionStrategy::ROUND_ROBIN_1D);
 
     BufferDistributionSpec(
         tt::tt_metal::Shape tensor_shape_in_pages,
         tt::tt_metal::Shape shard_shape_in_pages,
         CoreRangeSet core_range_set,
         ShardOrientation shard_orientation,
-        bool use_2d_grid_distribution = false);
+        ShardDistributionStrategy shard_distribution_strategy = ShardDistributionStrategy::ROUND_ROBIN_1D);
 
     tt::tt_metal::Shape get_tensor_shape_in_pages() const { return tensor_shape_in_pages_; }
     tt::tt_metal::Shape get_shard_shape_in_pages() const { return shard_shape_in_pages_; }
@@ -59,7 +59,8 @@ public:
     }
 
 private:
-    std::vector<CoreCoord> compute_core_list(const CoreRangeSet& core_range_set, bool use_2d_grid_distribution);
+    std::vector<CoreCoord> compute_core_list(
+        const CoreRangeSet& core_range_set, ShardDistributionStrategy shard_distribution_strategy);
 
     tt::tt_metal::Shape tensor_shape_in_pages_;
     tt::tt_metal::Shape shard_shape_in_pages_;

--- a/tt_metal/api/tt-metalium/buffer_types.hpp
+++ b/tt_metal/api/tt-metalium/buffer_types.hpp
@@ -21,6 +21,13 @@ enum class ShardOrientation {
     COL_MAJOR,
 };
 
+enum class ShardDistributionStrategy {
+    // Distribute each shard to each of the cores in a linearized list in a round-robin manner.
+    ROUND_ROBIN_1D = 0,
+    // Distribute a 2D grid of shards to a 2D grid of cores with one to one mapping.
+    GRID_2D = 1,
+};
+
 enum class ShardMode {
     PHYSICAL,  // TODO: Deprecate this option to treat shard shape as physical
     LOGICAL,

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -5,6 +5,8 @@
 #include "buffer_distribution_spec.hpp"
 #include "assert.hpp"
 
+#include <tt-metalium/math.hpp>
+
 #include <algorithm>
 
 namespace tt::tt_metal {
@@ -139,28 +141,63 @@ BufferDistributionSpec BufferDistributionSpec::from_shard_spec(
     tt::tt_metal::Shape shard_shape,
     tt::tt_metal::Shape2D page_shape,
     CoreRangeSet core_range_set,
-    ShardOrientation shard_orientation) {
+    ShardOrientation shard_orientation,
+    bool use_2d_grid_distribution) {
     auto tensor_shape_in_pages = CMAKE_UNIQUE_NAMESPACE::convert_shape_to_pages(tensor_shape, page_shape);
     auto shard_shape_in_pages = CMAKE_UNIQUE_NAMESPACE::convert_shape_to_pages(shard_shape, page_shape);
-    return BufferDistributionSpec(tensor_shape_in_pages, shard_shape_in_pages, core_range_set, shard_orientation);
+    return BufferDistributionSpec(
+        tensor_shape_in_pages, shard_shape_in_pages, core_range_set, shard_orientation, use_2d_grid_distribution);
 }
 
 BufferDistributionSpec::BufferDistributionSpec(
     tt::tt_metal::Shape tensor_shape_in_pages,
     tt::tt_metal::Shape shard_shape_in_pages,
     CoreRangeSet core_range_set,
-    ShardOrientation shard_orientation) :
+    ShardOrientation shard_orientation,
+    bool use_2d_grid_distribution) :
     shard_orientation_(shard_orientation) {
-    cores_ = corerange_to_cores(
-        core_range_set, core_range_set.num_cores(), shard_orientation_ == ShardOrientation::ROW_MAJOR);
     TT_FATAL(tensor_shape_in_pages.rank() >= 1, "Tensor rank must be at least 1!");
     TT_FATAL(shard_shape_in_pages.rank() >= 1, "Shard rank must be at least 1!");
     TT_FATAL(shard_shape_in_pages.volume() != 0, "Shard shape must have non zero volume!");
-    if (tensor_shape_in_pages.volume() != 0) {
-        TT_FATAL(cores_.size() != 0, "Can't distribute non zero volume tensor over an empty set of cores");
-    }
     std::tie(tensor_shape_in_pages_, shard_shape_in_pages_) =
         CMAKE_UNIQUE_NAMESPACE::squeeze_shape_ranks(tensor_shape_in_pages, shard_shape_in_pages);
+
+    cores_ = compute_core_list(core_range_set, use_2d_grid_distribution);
+    if (tensor_shape_in_pages_.volume() != 0) {
+        TT_FATAL(cores_.size() != 0, "Can't distribute non zero volume tensor over an empty set of cores");
+    }
+}
+
+std::vector<CoreCoord> BufferDistributionSpec::compute_core_list(
+    const CoreRangeSet& core_range_set, bool use_2d_grid_distribution) {
+    if (!use_2d_grid_distribution) {
+        return corerange_to_cores(
+            core_range_set, core_range_set.num_cores(), shard_orientation_ == ShardOrientation::ROW_MAJOR);
+    }
+
+    TT_FATAL(shard_shape_in_pages_.rank() <= 2, "2D grid distribution is only supported for 2D sharding!");
+    TT_FATAL(
+        core_range_set.ranges().size() == 1, "2D grid distribution is only supported for one contiguous core grid!");
+    auto core_grid = core_range_set.ranges()[0];
+
+    uint32_t num_shards_along_width = std::max(div_up(tensor_shape_in_pages_[-1], shard_shape_in_pages_[-1]), 1u);
+    uint32_t num_shards_along_height = std::max(div_up(tensor_shape_in_pages_[-2], shard_shape_in_pages_[-2]), 1u);
+    if (shard_orientation_ != ShardOrientation::ROW_MAJOR) {
+        std::swap(num_shards_along_width, num_shards_along_height);
+    }
+    TT_FATAL(
+        num_shards_along_width <= core_grid.grid_size().x,
+        "Number of shards along width must not exceed core grid width!");
+    TT_FATAL(
+        num_shards_along_height <= core_grid.grid_size().y,
+        "Number of shards along height must not exceed core grid height!");
+
+    CoreRange trimmed_core_grid = CoreRange(
+        core_grid.start_coord,
+        {core_grid.start_coord.x + num_shards_along_width - 1, core_grid.start_coord.y + num_shards_along_height - 1});
+
+    return corerange_to_cores(
+        trimmed_core_grid, trimmed_core_grid.size(), shard_orientation_ == ShardOrientation::ROW_MAJOR);
 }
 
 size_t BufferDistributionSpec::num_shards() const {

--- a/ttnn/api/ttnn/tensor/types.hpp
+++ b/ttnn/api/ttnn/tensor/types.hpp
@@ -92,10 +92,10 @@ struct NdShardSpec {
     Shape shard_shape;
     CoreRangeSet grid;
     ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
-    bool use_2d_grid_distribution = false;
+    ShardDistributionStrategy shard_distribution_strategy = ShardDistributionStrategy::ROUND_ROBIN_1D;
 
     NdShardSpec with_shard_shape(Shape new_shard_shape) const {
-        return NdShardSpec{std::move(new_shard_shape), grid, orientation, use_2d_grid_distribution};
+        return NdShardSpec{std::move(new_shard_shape), grid, orientation, shard_distribution_strategy};
     }
 
     bool operator==(const NdShardSpec& other) const = default;

--- a/ttnn/api/ttnn/tensor/types.hpp
+++ b/ttnn/api/ttnn/tensor/types.hpp
@@ -92,6 +92,11 @@ struct NdShardSpec {
     Shape shard_shape;
     CoreRangeSet grid;
     ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
+    bool use_2d_grid_distribution = false;
+
+    NdShardSpec with_shard_shape(Shape new_shard_shape) const {
+        return NdShardSpec{std::move(new_shard_shape), grid, orientation, use_2d_grid_distribution};
+    }
 
     bool operator==(const NdShardSpec& other) const = default;
     bool operator!=(const NdShardSpec& other) const = default;

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -223,7 +223,7 @@ BufferShardingArgs TensorLayout::compute_buffer_sharding_args(const ttnn::Shape&
             page_shape,
             nd_shard_spec->grid,
             nd_shard_spec->orientation,
-            nd_shard_spec->use_2d_grid_distribution);
+            nd_shard_spec->shard_distribution_strategy);
     }
     return BufferShardingArgs(
         std::move(distribution_spec), std::move(shard_spec_buffer), memory_config_.memory_layout());

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -218,7 +218,12 @@ BufferShardingArgs TensorLayout::compute_buffer_sharding_args(const ttnn::Shape&
     if (const auto& nd_shard_spec = memory_config_.nd_shard_spec()) {
         auto padded_shape = compute_padded_shape(shape);
         distribution_spec = BufferDistributionSpec::from_shard_spec(
-            padded_shape, nd_shard_spec->shard_shape, page_shape, nd_shard_spec->grid, nd_shard_spec->orientation);
+            padded_shape,
+            nd_shard_spec->shard_shape,
+            page_shape,
+            nd_shard_spec->grid,
+            nd_shard_spec->orientation,
+            nd_shard_spec->use_2d_grid_distribution);
     }
     return BufferShardingArgs(
         std::move(distribution_spec), std::move(shard_spec_buffer), memory_config_.memory_layout());

--- a/ttnn/core/tensor/tensor_spec.cpp
+++ b/ttnn/core/tensor/tensor_spec.cpp
@@ -166,20 +166,9 @@ MemoryConfig TensorSpec::populate_nd_shard_spec_from_legacy() const {
         nd_shard_spec.shard_shape = Shape({shard_spec.shape[1]});
     }
 
-    // For block sharding, we need to update the core grid to ensure the same distribution of shards
+    // For block sharding, we need to use 2D grid distribution to ensure the same distribution of shards
     if (mem_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        size_t num_shards_along_height = std::max(div_up(physical_shape().height(), shard_spec.shape[0]), 1u);
-        size_t num_shards_along_width = std::max(div_up(physical_shape().width(), shard_spec.shape[1]), 1u);
-        if (shard_spec.orientation != ShardOrientation::ROW_MAJOR) {
-            std::swap(num_shards_along_height, num_shards_along_width);
-        }
-        TT_FATAL(
-            shard_spec.grid.ranges().size() == 1, "Shard grid must be one full rectangular grid for block sharded!");
-        auto orig_cores = shard_spec.grid.ranges()[0];
-        nd_shard_spec.grid = CoreRangeSet(CoreRange(
-            orig_cores.start_coord,
-            {orig_cores.start_coord.x + num_shards_along_width - 1,
-             orig_cores.start_coord.y + num_shards_along_height - 1}));
+        nd_shard_spec.use_2d_grid_distribution = true;
     }
 
     return MemoryConfig::create_with_prepopulated_shard_specs(
@@ -244,10 +233,12 @@ std::optional<MemoryConfig> TensorSpec::populate_legacy_shard_spec_from_nd() con
     }
 
     TensorMemoryLayout shard_kind = TensorMemoryLayout::BLOCK_SHARDED;
-    if (shard_spec.shape[0] == padded_shape().volume() / padded_shape()[-1]) {
-        shard_kind = TensorMemoryLayout::WIDTH_SHARDED;
-    } else if (shard_spec.shape[1] == padded_shape()[-1]) {
-        shard_kind = TensorMemoryLayout::HEIGHT_SHARDED;
+    if (!nd_shard_spec.use_2d_grid_distribution) {
+        if (shard_spec.shape[0] == padded_shape().volume() / padded_shape()[-1]) {
+            shard_kind = TensorMemoryLayout::WIDTH_SHARDED;
+        } else if (shard_spec.shape[1] == padded_shape()[-1]) {
+            shard_kind = TensorMemoryLayout::HEIGHT_SHARDED;
+        }
     }
 
     if (shard_kind != TensorMemoryLayout::BLOCK_SHARDED) {
@@ -264,10 +255,15 @@ std::optional<MemoryConfig> TensorSpec::populate_legacy_shard_spec_from_nd() con
         return std::nullopt;
     }
 
-    // To match the shard distribution, the number of shards along the width must match to the grid exactly,
-    // and the number of shards along the height must fit into the grid.
+    // If 2D grid distribution is not used, we need number of shards along width to match the grid width to guarantee
+    // the same distribution of shards
     CoreCoord shard_grid = shard_spec.grid.ranges()[0].grid_size();
-    if (num_shards_along_width != shard_grid.x || num_shards_along_height > shard_grid.y) {
+    if (!nd_shard_spec.use_2d_grid_distribution && num_shards_along_width != shard_grid.x) {
+        return std::nullopt;
+    }
+
+    // To match the shard distribution, the number of shards along width and height must fit into the grid
+    if (num_shards_along_width > shard_grid.x || num_shards_along_height > shard_grid.y) {
         return std::nullopt;
     }
 


### PR DESCRIPTION
Migrated from upstream PR 24505