### PR TITLE
#19393: Fix untilize + bias + fp32 + packer_l1 accumulation in Conv2D

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -37,7 +37,7 @@ import torch
 )
 @pytest.mark.parametrize(
     "packer_l1_acc",
-    [False],
+    [True],
 )
 @pytest.mark.parametrize(
     "filter, padding",
@@ -75,9 +75,6 @@ def test_conv_features(
 
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
-
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat16 and packer_l1_acc and fp32_accum:
-        pytest.skip("skipping due to pack_untilize_dst issue!")
 
     run_conv(
         device,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -375,7 +375,7 @@ void MAIN {
             // if last block we pack the final result with relu enabled
             PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
 #endif
-            pack_reconfig_data_format(matmul_partials_cb, out_cb_id);
+            pack_reconfig_data_format(matmul_partials_cb, untilize_mode_out_cb_id);
 #ifdef PACKER_L1_ACC
             pack_reconfig_l1_acc(0);
 #endif


### PR DESCRIPTION
Migrated from upstream PR 24570