### PR TITLE
[skip ci] Fix typos in {INSTALLING,METALIUM_GUIDE}.md.

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -39,7 +39,7 @@ For users on other Linux distributions, please consult the `install_dependencies
 
 > [!IMPORTANT]
 >
-> Building with Clang 17 and GCC 12 is supported. Later versions, while not officially supported, should work. For Ubuntu 22.04 users, the default compiler is GCC 11 and Clang 14. Please install a newer compiler to ensure a successful build (the dependency installaion script will install Clang 17 for you).
+> Building with Clang 17 and GCC 12 is supported. Later versions, while not officially supported, should work. For Ubuntu 22.04 users, the default compiler is GCC 11 and Clang 14. Please install a newer compiler to ensure a successful build (the dependency installation script will install Clang 17 for you).
 
 
 ---
@@ -64,7 +64,7 @@ sudo modprobe tenstorrent
 cd ..
 ```
 
-- For more information visit Tenstorrents [TT-KMD GitHub repository](https://github.com/tenstorrent/tt-kmd).
+- For more information visit Tenstorrent's [TT-KMD GitHub repository](https://github.com/tenstorrent/tt-kmd).
 
 ---
 
@@ -93,7 +93,7 @@ pip install git+https://github.com/tenstorrent/tt-flash.git
   tt-flash flash --fw-tar $fw_pack
   ```
 
-- For more information visit Tenstorrent's [TT-Firmware GitHub Repository](https://github.com/tenstorrent/tt-firmware) and [TT-Flash Github Repository](https://github.com/tenstorrent/tt-flash).
+- For more information visit Tenstorrent's [TT-Firmware GitHub Repository](https://github.com/tenstorrent/tt-firmware) and [TT-Flash GitHub Repository](https://github.com/tenstorrent/tt-flash).
 
 ---
 
@@ -148,7 +148,7 @@ Once hardware and system software are installed, verify that the system has been
 
 - [Option 4: From Anaconda](#anaconda)
 
-  Installing from Anaconda can be convienient for ML Developers who prefer that workflow.
+  Installing from Anaconda can be convenient for ML Developers who prefer that workflow.
 
 ---
 
@@ -230,7 +230,7 @@ ninja
 ninja install # Installs to build directory by default, required for Python environment
 ```
 
-#### Step 3. Crate a virtual environment and (optional) documentation.
+#### Step 3. Create a virtual environment and (optional) documentation.
 
 - (recommended) For an out-of-the-box virtual environment to use, execute:
 ```

--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -238,7 +238,7 @@ The 32×32 tile size allows hardware to process data efficiently within a few cl
 
 <img width="900" alt="image" src="docs/source/common/images/matmul-blocked-row-column-diagram.webp">
 
-GPUs often struggle to efficiently supply data to their tensor cores because their architectures are primarily designed around vector operations. This can lead to less optimal memory access patterns for tensor workloads. In contrast, Tenstorrent hardware is built for tile-based computation from the start—both the vector and matrix units operate natively on 32×32 tiles. This approach leads to more predictable performance and a simpler programming model. For detailed performance numbers, see the [Matrix Multiplcation performance report](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/GEMM_FLOPS/GEMM_FLOPS.md) as well as the [Convolution Networks on Tenstorrent Chips](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/CNNs/ttcnn.md) report.
+GPUs often struggle to efficiently supply data to their tensor cores because their architectures are primarily designed around vector operations. This can lead to less optimal memory access patterns for tensor workloads. In contrast, Tenstorrent hardware is built for tile-based computation from the start—both the vector and matrix units operate natively on 32×32 tiles. This approach leads to more predictable performance and a simpler programming model. For detailed performance numbers, see the [Matrix Multiplication performance report](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/GEMM_FLOPS/GEMM_FLOPS.md) as well as the [Convolution Networks on Tenstorrent Chips](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/CNNs/ttcnn.md) report.
 
 ### Where is the cache hierarchy
 
@@ -487,7 +487,7 @@ inline void calculate_sine() {
 }
 ```
 
-For Blackhole (and Wormhole) processors, the availability of `float_to_int16` instruction enables reliable value shifting to the [-π, π] range. The implementation then applies a MacLaurin series calculation for sine computation (utilizing the same mathematical approach but with processor-specific function naming). Additionally, the ITERATIONS parameter differs between processor generations (not shown in code here, it is set by an ourside source): Grayskull requires 4 iterations, while Wormhole and Blackhole require 8 iterations to accommodate their reduced vector width of 32 elements compared to Grayskull's 64-element vectors.
+For Blackhole (and Wormhole) processors, the availability of `float_to_int16` instruction enables reliable value shifting to the [-π, π] range. The implementation then applies a MacLaurin series calculation for sine computation (utilizing the same mathematical approach but with processor-specific function naming). Additionally, the ITERATIONS parameter differs between processor generations (not shown in code here, it is set by an outside source): Grayskull requires 4 iterations, while Wormhole and Blackhole require 8 iterations to accommodate their reduced vector width of 32 elements compared to Grayskull's 64-element vectors.
 
 ```c++
 // tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -537,7 +537,7 @@ Unlike OpenCL's command queue which optionally supports out-of-order execution, 
 // Wait for the current tail operation on queue 0 to complete
 // before proceeding on command queue 1
 auto event = EnqueueRecordEvent(device->command_queue(0));
-EnququeWaitForEvent(device->command_queue(1), event);
+EnqueueWaitForEvent(device->command_queue(1), event);
 ```
 
 ### SPMD in Metalium
@@ -579,7 +579,7 @@ for(uint32_t y = core_range.start.y; y < core_range.end.y; y++) {
 }
 ```
 
-Metalium provides the `tt::tt_metal::split_work_to_cores` utility function to distribute work across available cores for SPMD execution. The function takes the total number of tiles and available cores, then calculates how to divide the work when it cannot be evenly distributed. The function returns two groups of cores: a primary group that handles more tiles per core, and a secondary group that handles fewer, along with the tile count for each group. Minimizing workload inbalance between cores (if work can be evenly distributed, the secondary group will be empty.)
+Metalium provides the `tt::tt_metal::split_work_to_cores` utility function to distribute work across available cores for SPMD execution. The function takes the total number of tiles and available cores, then calculates how to divide the work when it cannot be evenly distributed. The function returns two groups of cores: a primary group that handles more tiles per core, and a secondary group that handles fewer, along with the tile count for each group. Minimizing workload imbalance between cores (if work can be evenly distributed, the secondary group will be empty.)
 
 ```c++
 auto core_grid = device->compute_with_storage_grid_size();
@@ -595,7 +595,7 @@ auto [num_cores, // number of cores utilized
 Only create kernels on cores that have been assigned work (i.e., those in `all_cores` or `core_group_*`). Avoid creating kernels on unused cores, as this can cause undefined behavior or crashes if kernels are created but runtime arguments are not set on the core. If there is not enough work, some cores may remain idle—do not assign kernels to them.
 
 ```c++
-// `all_cores` is guarenteed to be the union of `core_group_1` and `core_group_2`.
+// `all_cores` is guaranteed to be the union of `core_group_1` and `core_group_2`.
 for (const auto& core : all_cores) {
     // Good
     CreateKernel(program, "/path/to/reader.cpp", all_cores, DataMovementConfig{...});


### PR DESCRIPTION
Migrated from upstream PR 24762