### PR TITLE
#0: Only disable kernel cache after compiling FD programs if it wasn't originally enabled

### DIFF
--- a/tt_metal/api/tt-metalium/persistent_kernel_cache.hpp
+++ b/tt_metal/api/tt-metalium/persistent_kernel_cache.hpp
@@ -23,4 +23,11 @@ void EnablePersistentKernelCache();
  */
 void DisablePersistentKernelCache();
 
+/**
+ * Returns true if the kernel compilation cache is enabled.
+ *
+ * Return value: bool
+ */
+bool GetPersistentKernelCacheEnabled();
+
 }  // namespace tt::tt_metal::detail

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1172,7 +1172,9 @@ void create_cq_program(IDevice* device) {
 }
 
 void compile_cq_programs() {
-    if (tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
+    bool temp_enable_kernel_cache = tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw() &&
+                                    !detail::GetPersistentKernelCacheEnabled();
+    if (temp_enable_kernel_cache) {
         detail::EnablePersistentKernelCache();
     }
 
@@ -1181,7 +1183,7 @@ void compile_cq_programs() {
     // Write runtime args to device
     command_queue_compile_group.write_runtime_args(/*force_slow_dispatch=*/true);
 
-    if (tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
+    if (temp_enable_kernel_cache) {
         detail::DisablePersistentKernelCache();
     }
 }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -231,6 +231,8 @@ void EnablePersistentKernelCache() { enable_persistent_kernel_cache = true; }
 
 void DisablePersistentKernelCache() { enable_persistent_kernel_cache = false; }
 
+bool GetPersistentKernelCacheEnabled() { return enable_persistent_kernel_cache; }
+
 class Internal_ {
    public:
        using map_type = decltype(detail::ProgramImpl::circular_buffer_by_id_);

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "assert.hpp"
+#include <tt-metalium/persistent_kernel_cache.hpp>
 #include <umd/device/tt_core_coordinates.h>
 
 using std::vector;
@@ -236,6 +237,10 @@ RunTimeOptions::RunTimeOptions() {
 
     if (getenv("TT_METAL_FORCE_REINIT")) {
         force_context_reinit = true;
+    }
+
+    if (getenv("TT_METAL_ENABLE_PERSISTENT_KERNEL_CACHE")) {
+        tt::tt_metal::detail::EnablePersistentKernelCache();
     }
 }
 


### PR DESCRIPTION
Migrated from upstream PR 25205